### PR TITLE
330 consecutive imputation links

### DIFF
--- a/src/cumulative_imputation_links.py
+++ b/src/cumulative_imputation_links.py
@@ -4,12 +4,12 @@ import numpy as np
 def get_cumulative_links(
     dataframe,
     forward_or_backward,
-    time_difference,
     strata,
     reference,
     target,
     period,
     imputation_link,
+    time_difference=1,
 ):
     """
     Create cumulative imputation links for multiple consecutive periods
@@ -20,8 +20,7 @@ def get_cumulative_links(
     dataframe : pandas.DataFrame
     forward_or_backward: str
         either f or b for forward or backward method
-    time_difference : int
-        time difference between predictive and target period in months
+
     strata : str
         column name containing strata information (sic)
     reference : str
@@ -32,6 +31,8 @@ def get_cumulative_links(
         column name containing time period
     imputation_link : string
         column name containing imputation links
+    time_difference : int
+        time difference between predictive and target period in months
 
     Returns
     -------
@@ -61,5 +62,11 @@ def get_cumulative_links(
         dataframe["cumulative_" + imputation_link] = (
             dataframe[::-1].groupby("imputation_group")[imputation_link].cumprod()[::-1]
         )
+
+    dataframe["cumulative_" + imputation_link] = np.where(
+        ~dataframe[target].isnull(),
+        np.nan,
+        dataframe["cumulative_" + imputation_link],
+    )
 
     return dataframe[["imputation_group", "cumulative_" + imputation_link]]

--- a/src/cumulative_imputation_links.py
+++ b/src/cumulative_imputation_links.py
@@ -1,58 +1,65 @@
-import pandas as pd
 import numpy as np
 
 
-def get_cumulative_links(dataframe, forward_or_backward, time_difference, strata, reference, target, period, imputation_link):
+def get_cumulative_links(
+    dataframe,
+    forward_or_backward,
+    time_difference,
+    strata,
+    reference,
+    target,
+    period,
+    imputation_link,
+):
     """
-    Create cumulative imputation links for multiple consecutive periods without a return.
+    Create cumulative imputation links for multiple consecutive periods
+    without a return.
 
     Parameters
     ----------
     dataframe : pandas.DataFrame
     forward_or_backward: str
         either f or b for forward or backward method
+    time_difference : int
+        time difference between predictive and target period in months
+    strata : str
+        column name containing strata information (sic)
+    reference : str
+        column name containing business reference id
     target : str
         column name containing target variable
     period : str
         column name containing time period
-    reference : str
-        column name containing business reference id
-    strata : str
-        column name containing strata information (sic)
-    time_difference : int
-        time difference between predictive and target period in months
     imputation_link : string
         column name containing imputation links
 
     Returns
     -------
     pandas.DataFrame
-        dataframe with additional missing_value, imputation group and 
-        cumulative_imputation_link column
+        dataframe with imputation_group and
+        cumulative_forward/backward_imputation_link column
     """
-    
-    dataframe.sort_values([strata, reference, period], inplace=True)    
+
+    dataframe.sort_values([strata, reference, period], inplace=True)
     dataframe["missing_value"] = np.where(dataframe[target].isnull(), True, False)
-    
+
     dataframe["imputation_group"] = (
-        ((dataframe["missing_value"].diff(time_difference) != 0) |
-        (dataframe[strata].diff(time_difference) != 0) |
-        (dataframe[reference].diff(time_difference) != 0))
-    .astype("int")
-    .cumsum()
-    )
-    
-    if forward_or_backward == "f":
-        dataframe["cumulative_"+imputation_link] = (
-            dataframe.groupby("imputation_group")[imputation_link]
-            .cumprod()
+        (
+            (dataframe["missing_value"].diff(time_difference) != 0)
+            | (dataframe[strata].diff(time_difference) != 0)
+            | (dataframe[reference].diff(time_difference) != 0)
         )
+        .astype("int")
+        .cumsum()
+    )
+
+    if forward_or_backward == "f":
+        dataframe["cumulative_" + imputation_link] = dataframe.groupby(
+            "imputation_group"
+        )[imputation_link].cumprod()
     elif forward_or_backward == "b":
-        dataframe["cumulative_"+imputation_link] = (
-            dataframe[::-1].groupby("imputation_group")[imputation_link]
-            .cumprod()[::-1]
-        )        
-    
-    return dataframe[["imputation_group", "cumulative_"+imputation_link]]
+        dataframe["cumulative_" + imputation_link] = (
+            dataframe[::-1].groupby("imputation_group")[imputation_link].cumprod()[::-1]
+        )
 
-
+    return dataframe[["imputation_group", "cumulative_" + imputation_link]]

--- a/src/multiply_imputation_links.py
+++ b/src/multiply_imputation_links.py
@@ -1,0 +1,58 @@
+import pandas as pd
+
+
+def get_cumulative_links(dataframe, forward_or_backward, time_difference, strata, reference, target, period, imputation_link):
+    """
+    Create cumulative imputation links for multiple consecutive periods without a return.
+
+    Parameters
+    ----------
+    dataframe : pandas.DataFrame
+    forward_or_backward: str
+        either f or b for forward or backward method
+    target : str
+        column name containing target variable
+    period : str
+        column name containing time period
+    reference : str
+        column name containing business reference id
+    strata : str
+        column name containing strata information (sic)
+    time_difference : int
+        time difference between predictive and target period in months
+    imputation_link : string
+        column name containing imputation links
+
+    Returns
+    -------
+    pandas.DataFrame
+        dataframe with additional missing_value, imputation group and 
+        cumulative_imputation_link column
+    """
+
+    if forward_or_backward == "f":
+        pass
+    elif forward_or_backward == "b":
+        time_difference = -time_difference
+        
+    dataframe.sort_values([strata, reference, period], inplace=True)
+    dataframe["missing_value"] = np.where(df[target].isnull(), True, False)
+    
+    dataframe["imputation_group"] = (
+        (dataframe["missing_value"].diff(time_difference) != 0)
+    .astype("int")
+    .cumsum()
+    )
+    
+    if forward_or_backward == "f":
+        dataframe["cumulative_"+imputation_link] = (
+            dataframe.groupby("imputation_group")[imputation_link]
+            .cumprod()
+        )
+    elif forward_or_backward == "b":
+        dataframe["cumulative_"+imputation_link] = (
+            dataframe.groupby("imputation_group")[imputation_link][::-1]
+            .cumprod()[::-1]
+        )        
+    
+    return dataframe

--- a/tests/cumulative_links.csv
+++ b/tests/cumulative_links.csv
@@ -1,0 +1,7 @@
+strata,reference,target,period,forward_imputation_link,backward_imputation_link,imputation_group,cumulative_forward_imputation_link,cumulative_backward_imputation_link
+100,100000,200,202402,1,2,1,1,2
+100,100000,,202403,2,0.6,2,2,0.6
+100,100000,,202404,3,1,2,6,1
+200,100001,,202402,1,4,3,1,2
+200,100001,,202403,3,0.5,3,3,0.5
+200,100001,300,202404,0.5,1,4,0.5,1

--- a/tests/cumulative_links.csv
+++ b/tests/cumulative_links.csv
@@ -1,7 +1,7 @@
 strata,reference,target,period,forward_imputation_link,backward_imputation_link,imputation_group,cumulative_forward_imputation_link,cumulative_backward_imputation_link
-100,100000,200,202402,1,2,1,1,2
+100,100000,200,202402,1,2,1,,
 100,100000,,202403,2,0.6,2,2,0.6
 100,100000,,202404,3,1,2,6,1
 200,100001,,202402,1,4,3,1,2
 200,100001,,202403,3,0.5,3,3,0.5
-200,100001,300,202404,0.5,1,4,0.5,1
+200,100001,300,202404,0.5,1,4,,

--- a/tests/test_cumulative_imputation_links.py
+++ b/tests/test_cumulative_imputation_links.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+import pytest
+from helper_functions import load_and_format
+from pandas.testing import assert_frame_equal
+
+from src.cumulative_imputation_links import get_cumulative_links
+
+@pytest.fixture(scope="class")
+def cumulative_links_test_data():
+    return load_and_format(Path("tests") / "cumulative_links.csv")
+
+
+class TestComulativeLinks:
+    def test_get_cumulative_links_forward(self, cumulative_links_test_data):
+        input_data = (
+            cumulative_links_test_data.drop(
+                columns=["cumulative_forward_imputation_link",
+                         "imputation_group"])
+        )
+        
+        expected_output = cumulative_links_test_data[
+            [
+                "imputation_group",
+                "cumulative_forward_imputation_link",
+            ]
+        ]
+
+
+        actual_output = get_cumulative_links(
+            input_data, "f", 1, "strata", "reference", "target", "period",
+            "forward_imputation_link"
+        )
+
+        assert_frame_equal(actual_output, expected_output)
+
+    
+    def test_get_cumulative_links_backward(self, cumulative_links_test_data):
+        input_data = (
+            cumulative_links_test_data.drop(
+                columns=["cumulative_backward_imputation_link",
+                         "imputation_group"])
+        )
+        
+        expected_output = cumulative_links_test_data[
+            [
+                "imputation_group",
+                "cumulative_backward_imputation_link",
+            ]
+        ]
+
+
+        actual_output = get_cumulative_links(
+            input_data, "b", 1, "strata", "reference", "target", "period",   
+            "backward_imputation_link"
+        )
+
+        assert_frame_equal(actual_output, expected_output)

--- a/tests/test_cumulative_imputation_links.py
+++ b/tests/test_cumulative_imputation_links.py
@@ -28,12 +28,12 @@ class TestComulativeLinks:
         actual_output = get_cumulative_links(
             input_data,
             "f",
-            1,
             "strata",
             "reference",
             "target",
             "period",
             "forward_imputation_link",
+            1,
         )
 
         assert_frame_equal(actual_output, expected_output)
@@ -53,12 +53,12 @@ class TestComulativeLinks:
         actual_output = get_cumulative_links(
             input_data,
             "b",
-            1,
             "strata",
             "reference",
             "target",
             "period",
             "backward_imputation_link",
+            1,
         )
 
         assert_frame_equal(actual_output, expected_output)

--- a/tests/test_cumulative_imputation_links.py
+++ b/tests/test_cumulative_imputation_links.py
@@ -6,6 +6,7 @@ from pandas.testing import assert_frame_equal
 
 from src.cumulative_imputation_links import get_cumulative_links
 
+
 @pytest.fixture(scope="class")
 def cumulative_links_test_data():
     return load_and_format(Path("tests") / "cumulative_links.csv")
@@ -13,12 +14,10 @@ def cumulative_links_test_data():
 
 class TestComulativeLinks:
     def test_get_cumulative_links_forward(self, cumulative_links_test_data):
-        input_data = (
-            cumulative_links_test_data.drop(
-                columns=["cumulative_forward_imputation_link",
-                         "imputation_group"])
+        input_data = cumulative_links_test_data.drop(
+            columns=["cumulative_forward_imputation_link", "imputation_group"]
         )
-        
+
         expected_output = cumulative_links_test_data[
             [
                 "imputation_group",
@@ -26,22 +25,24 @@ class TestComulativeLinks:
             ]
         ]
 
-
         actual_output = get_cumulative_links(
-            input_data, "f", 1, "strata", "reference", "target", "period",
-            "forward_imputation_link"
+            input_data,
+            "f",
+            1,
+            "strata",
+            "reference",
+            "target",
+            "period",
+            "forward_imputation_link",
         )
 
         assert_frame_equal(actual_output, expected_output)
 
-    
     def test_get_cumulative_links_backward(self, cumulative_links_test_data):
-        input_data = (
-            cumulative_links_test_data.drop(
-                columns=["cumulative_backward_imputation_link",
-                         "imputation_group"])
+        input_data = cumulative_links_test_data.drop(
+            columns=["cumulative_backward_imputation_link", "imputation_group"]
         )
-        
+
         expected_output = cumulative_links_test_data[
             [
                 "imputation_group",
@@ -49,10 +50,15 @@ class TestComulativeLinks:
             ]
         ]
 
-
         actual_output = get_cumulative_links(
-            input_data, "b", 1, "strata", "reference", "target", "period",   
-            "backward_imputation_link"
+            input_data,
+            "b",
+            1,
+            "strata",
+            "reference",
+            "target",
+            "period",
+            "backward_imputation_link",
         )
 
         assert_frame_equal(actual_output, expected_output)


### PR DESCRIPTION
# Summary

Multiple consecutive missing values need imputation links to be multiplied to apply the correct imputation link. This function creates two new columns onto the input DataFrame, one for imputation_group that defines consecutive missing values, and another column for cumulative links.

# Checklists

<!--
These are do-confirm checklists; it confirms that you have done each item.

If actions are irrelevant, please add a comment stating why.

Incomplete pull/merge requests may be blocked until actions are resolved, or closed at
the reviewers' discretion.
-->

This pull request meets the following requirements:

- [x] installable with all dependencies recorded
- [x] runs without error
- [x] follows PEP8 and project specific conventions
- [x] appropriate use of comments, for example no descriptive comments
- [x] functions documented using Numpy style docstings
- [x] assumptions and decisions log considered and updated if appropriate
- [x] unit tests have been updated to cover essential functionality for a reasonable range of inputs and conditions
- [x] other forms of testing such as end-to-end and user-interface testing have been considered and updated as required
- [x] tests suite passes (locally as a minimum)
- [x] peer reviewed with review recorded

If you feel some of these conditions do not apply for this pull request, please
add a comment to explain why.
