### PR TITLE
331 apply imputation link to target

### DIFF
--- a/src/apply_imputation_link.py
+++ b/src/apply_imputation_link.py
@@ -4,76 +4,145 @@ df = pd.read_csv(
     "monthly-business-survey-results/tests/apply_imputation_link.csv"
 ).drop(columns="imputed_value")
 
-df.sort_values(["strata", "reference", "period"], inplace=True)
 
-grouped_target = df.groupby(["strata", "reference"])["target"]
-
-df["fir"] = grouped_target.ffill() * df["cumulative_forward_imputation_link"]
-df["bir"] = grouped_target.bfill() * df["cumulative_backward_imputation_link"]
-
-df.loc[df["imputation_marker"] == "C", "imputed_value"] = (
-    df["construction_link"] * df["auxiliary_variable"]
-)
-
-df["fic"] = (
-    df.groupby(["strata", "reference"])["imputed_value"].ffill()
-    * df["cumulative_forward_imputation_link"]
-)
-
-marker_column_mapping = {"FIR": "fir", "BIR": "bir", "FIC": "fic"}
-
-
-def add_to_imputation_column(df, marker, column):
-    df.loc[df["imputation_marker"] == marker, "imputed_value"] = df[column]
-    return df
-
-
-for marker, column in marker_column_mapping.items():
-    df = add_to_imputation_column(df, marker, column)
-
-df.drop(columns=marker_column_mapping.values(), inplace=True)
-
-
-def get_impute(
-    dataframe,
-    forward_or_backward,
-    strata,
-    reference,
-    target,
-    period,
-    imputation_link,
-    time_difference=1,
+def create_and_merge_imputation_values(
+    df, imputation_class, reference, period, marker, combined_imputation
 ):
     """
-    Create cumulative imputation links for multiple consecutive periods
-    without a return.
+    Loop through different imputation types and merge the results according
+    to an imputation marker column
 
     Parameters
     ----------
-    dataframe : pandas.DataFrame
-    forward_or_backward: str
-        either f or b for forward or backward method
-
-    strata : str
-        column name containing strata information (sic)
+    df : pandas.DataFrame
+    imputation_class: str
+        column name for the variable that defines the imputation class
     reference : str
-        column name containing business reference id
-    target : str
-        column name containing target variable
+        column name for the reference
     period : str
-        column name containing time period
-    imputation_link : string
-        column name containing imputation links
-    time_difference : int
-        time difference between predictive and target period in months
+        column name for the period
+    marker : str
+        column name containing a marker to indicate the type of imputation required
+    combined_imputation : str
+        column name for the combined imputation types according to the imputation marker
 
     Returns
     -------
     pandas.DataFrame
-        dataframe with imputation_group and
-        cumulative_forward/backward_imputation_link column
+        dataframe with imputation values defined by the imputation marker
+    """
+    # constructed has to come first to use the result for forward impute from contructed
+    imputation_config = {
+        "c": {
+            "intermediate_column": "constructed",
+            "marker": "C",
+            "fill_column": "auxiliary_variable",
+            # doesn't actually apply a fill so can be forward or back
+            "fill_method": "ffill",
+            "link_column": "construction_link",
+        },
+        "fir": {
+            "intermediate_column": "fir",
+            "marker": "FIR",
+            "fill_column": "target",
+            "fill_method": "ffill",
+            "link_column": "cumulative_forward_imputation_link",
+        },
+        "bir": {
+            "intermediate_column": "bir",
+            "marker": "BIR",
+            "fill_column": "target",
+            "fill_method": "bfill",
+            "link_column": "cumulative_backward_imputation_link",
+        },
+        "fic": {
+            "intermediate_column": "fic",
+            "marker": "FIC",
+            # this has to have the same name as the intermediate column for constructed
+            "fill_column": "constructed",
+            "fill_method": "ffill",
+            "link_column": "cumulative_forward_imputation_link",
+        },
+    }
+
+    df.sort_values([imputation_class, reference, period], inplace=True)
+
+    intermediate_columns = []
+
+    for imp_type in imputation_config:
+        df = create_impute(
+            df, [imputation_class, reference], imputation_config[imp_type]
+        )
+        df = merge_imputation_type(
+            df, imputation_config[imp_type], marker, combined_imputation
+        )
+
+        intermediate_columns.append(imputation_config[imp_type]["intermediate_column"])
+
+    return df.drop(columns=intermediate_columns)
+
+
+def create_impute(df, group, imputation_spec):
+    """
+    Add a new column to a dataframe of imputed values using ratio imputation.
+
+    Parameters
+    ----------
+    dataframe : pandas.DataFrame
+    group : str or list
+        variables that define the imputation class
+    imputation_spec: dict
+        dictionary defining the details of the imputation type
+
+    Returns
+    -------
+    pandas.DataFrame
+        dataframe with an added imputation column defined by the imputation_spec
+    """
+    column_name = imputation_spec["intermediate_column"]
+    fill_column = imputation_spec["fill_column"]
+    fill_method = imputation_spec["fill_method"]
+    link_column = imputation_spec["link_column"]
+
+    df[column_name] = (
+        df.groupby(group)[fill_column].fillna(method=fill_method) * df[link_column]
+    )
+    return df
+
+
+def merge_imputation_type(df, imputation_spec, marker, combined_imputation):
+    """
+    Uses an existing column of imputed values and a imputation marker to merge values
+    into a single column
+
+    Parameters
+    ----------
+    dataframe : pandas.DataFrame
+    imputation_spec: dict
+        dictionary defining the details of the imputation type
+    marker : str
+        column name containing a marker to indicate the type of imputation required
+    combined_imputation : str
+        column name for the combined imputation types according to the imputation marker
+
+    Returns
+    -------
+    pandas.DataFrame
+        dataframe with combined_imputation
     """
 
-    dataframe.sort_values([strata, reference, period], inplace=True)
+    imputation_marker = imputation_spec["marker"]
+    imputation_column = imputation_spec["intermediate_column"]
 
-    return dataframe[["imputation_group", "cumulative_" + imputation_link]]
+    df.loc[df[marker] == imputation_marker, combined_imputation] = df[imputation_column]
+    return df
+
+
+marker = "imputation_marker"
+combined_imputation = "imputed_value"
+reference = "reference"
+period = "period"
+imputation_class = "strata"
+df_new = create_and_merge_imputation_values(
+    df, imputation_class, reference, period, marker, combined_imputation
+)

--- a/src/apply_imputation_link.py
+++ b/src/apply_imputation_link.py
@@ -1,0 +1,79 @@
+import pandas as pd
+
+df = pd.read_csv(
+    "monthly-business-survey-results/tests/apply_imputation_link.csv"
+).drop(columns="imputed_value")
+
+df.sort_values(["strata", "reference", "period"], inplace=True)
+
+grouped_target = df.groupby(["strata", "reference"])["target"]
+
+df["fir"] = grouped_target.ffill() * df["cumulative_forward_imputation_link"]
+df["bir"] = grouped_target.bfill() * df["cumulative_backward_imputation_link"]
+
+df.loc[df["imputation_marker"] == "C", "imputed_value"] = (
+    df["construction_link"] * df["auxiliary_variable"]
+)
+
+df["fic"] = (
+    df.groupby(["strata", "reference"])["imputed_value"].ffill()
+    * df["cumulative_forward_imputation_link"]
+)
+
+marker_column_mapping = {"FIR": "fir", "BIR": "bir", "FIC": "fic"}
+
+
+def add_to_imputation_column(df, marker, column):
+    df.loc[df["imputation_marker"] == marker, "imputed_value"] = df[column]
+    return df
+
+
+for marker, column in marker_column_mapping.items():
+    df = add_to_imputation_column(df, marker, column)
+
+df.drop(columns=marker_column_mapping.values(), inplace=True)
+
+
+def get_impute(
+    dataframe,
+    forward_or_backward,
+    strata,
+    reference,
+    target,
+    period,
+    imputation_link,
+    time_difference=1,
+):
+    """
+    Create cumulative imputation links for multiple consecutive periods
+    without a return.
+
+    Parameters
+    ----------
+    dataframe : pandas.DataFrame
+    forward_or_backward: str
+        either f or b for forward or backward method
+
+    strata : str
+        column name containing strata information (sic)
+    reference : str
+        column name containing business reference id
+    target : str
+        column name containing target variable
+    period : str
+        column name containing time period
+    imputation_link : string
+        column name containing imputation links
+    time_difference : int
+        time difference between predictive and target period in months
+
+    Returns
+    -------
+    pandas.DataFrame
+        dataframe with imputation_group and
+        cumulative_forward/backward_imputation_link column
+    """
+
+    dataframe.sort_values([strata, reference, period], inplace=True)
+
+    return dataframe[["imputation_group", "cumulative_" + imputation_link]]

--- a/tests/apply_imputation_link.csv
+++ b/tests/apply_imputation_link.csv
@@ -1,0 +1,7 @@
+strata,reference,target,period,forward_imputation_link,backward_imputation_link,imputation_group,cumulative_forward_imputation_link,cumulative_backward_imputation_link,imputation_marker,imputed_value
+100,100000,200,202402,1,2,1,,,R,
+100,100000,,202403,2,0.6,2,2,0.6,FIR,400
+100,100000,,202404,3,1,2,6,1,FIR,1200
+200,100001,,202402,1,4,3,1,2,BIR,600
+200,100001,,202403,3,0.5,3,3,0.5,BIR,150
+200,100001,300,202404,0.5,1,4,,,R,

--- a/tests/apply_imputation_link.csv
+++ b/tests/apply_imputation_link.csv
@@ -1,7 +1,10 @@
-strata,reference,target,period,forward_imputation_link,backward_imputation_link,imputation_group,cumulative_forward_imputation_link,cumulative_backward_imputation_link,imputation_marker,imputed_value
-100,100000,200,202402,1,2,1,,,R,
-100,100000,,202403,2,0.6,2,2,0.6,FIR,400
-100,100000,,202404,3,1,2,6,1,FIR,1200
-200,100001,,202402,1,4,3,1,2,BIR,600
-200,100001,,202403,3,0.5,3,3,0.5,BIR,150
-200,100001,300,202404,0.5,1,4,,,R,
+strata,reference,target,period,forward_imputation_link,backward_imputation_link,imputation_group,cumulative_forward_imputation_link,cumulative_backward_imputation_link,imputation_marker,imputed_value,auxiliary_variable,construction_link
+100,100000,200,202402,1,2,1,,,R,,,
+100,100000,,202403,2,0.6,2,2,0.6,FIR,400,,
+100,100000,,202404,3,1,2,6,1,FIR,1200,,
+200,100001,,202402,1,4,3,1,2,BIR,600,,
+200,100001,,202403,3,0.5,3,3,0.5,BIR,150,,
+200,100001,300,202404,0.5,1,4,,,R,,,
+300,100002,,202402,1,4,5,1,2,C,600,40,0.1
+300,100002,,202403,3,0.5,5,3,0.5,FIC,150,,
+300,100002,,202404,0.5,1,5,2,,FIC,,,

--- a/tests/data/apply_imputation_link/BIR.csv
+++ b/tests/data/apply_imputation_link/BIR.csv
@@ -1,0 +1,4 @@
+imputation_class,reference,target,period,backward_imputation_link,cumulative_backward_imputation_link,imputation_marker,imputed_value
+200,100001,,202402,4,2,BIR,600
+200,100001,,202403,0.5,0.5,BIR,150
+200,100001,300,202404,1,,R,

--- a/tests/data/apply_imputation_link/C_FIC.csv
+++ b/tests/data/apply_imputation_link/C_FIC.csv
@@ -1,0 +1,4 @@
+imputation_class,reference,target,period,forward_imputation_link,cumulative_forward_imputation_link,construction_link,auxiliary_variable,imputation_marker,imputed_value
+300,100002,,202402,1,,0.1,1000,C,100
+300,100002,,202403,3,3,,,FIC,300
+300,100002,,202404,0.5,1.5,,,FIC,150

--- a/tests/data/apply_imputation_link/FIR.csv
+++ b/tests/data/apply_imputation_link/FIR.csv
@@ -1,0 +1,4 @@
+imputation_class,reference,target,period,forward_imputation_link,cumulative_forward_imputation_link,imputation_marker,imputed_value
+100,100000,200,202402,1,,R,
+100,100000,,202403,2,2,FIR,400
+100,100000,,202404,3,6,FIR,1200

--- a/tests/data/apply_imputation_link/FIR_BIR_C_FIC.csv
+++ b/tests/data/apply_imputation_link/FIR_BIR_C_FIC.csv
@@ -1,0 +1,10 @@
+imputation_class,reference,target,period,forward_imputation_link,backward_imputation_link,auxiliary_variable,construction_link,cumulative_forward_link,cumulative_backward_link,imputation_marker,imputed_value
+100,100000,200,202402,1,2,,,,,R,
+100,100000,,202403,2,0.6,,,2,0.6,FIR,400
+100,100000,,202404,3,1,,,6,1,FIR,1200
+200,100001,,202402,1,4,,,1,2,BIR,600
+200,100001,,202403,3,0.5,,,3,0.5,BIR,150
+200,100001,300,202404,0.5,1,,,,,R,
+300,100002,,202402,1,4,1000,0.1,,2,C,100
+300,100002,,202403,3,0.5,,,3,0.5,FIC,300
+300,100002,,202404,0.5,1,,,1.5,,FIC,150

--- a/tests/test_apply_imputation_link.py
+++ b/tests/test_apply_imputation_link.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+import pytest
+from helper_functions import load_and_format
+from pandas.testing import assert_frame_equal
+
+from src.apply_imputation_link import create_and_merge_imputation_values
+
+
+@pytest.fixture(scope="class")
+def fir_bir_c_fic_test_data():
+    return load_and_format(
+        Path("tests") / "data" / "apply_imputation_link" / "FIR_BIR_C_FIC.csv"
+    )
+
+
+class TestApplyImputationLink:
+    def test_all_imputation_types(self, fir_bir_c_fic_test_data):
+        expected_output = fir_bir_c_fic_test_data
+
+        input_data = expected_output.drop(columns=["imputed_value"])
+        actual_output = create_and_merge_imputation_values(
+            input_data,
+            "imputation_class",
+            "reference",
+            "period",
+            "imputation_marker",
+            "imputed_value",
+            "target",
+            "cumulative_forward_link",
+            "cumulative_backward_link",
+            "auxiliary_variable",
+            "construction_link",
+            imputation_types=("c", "fir", "bir", "fic"),
+        )
+
+        assert_frame_equal(actual_output, expected_output)


### PR DESCRIPTION
# Summary

With the correct imputation link, the correct "value to impute off" and correct impute marker in place we can calculate the relevant imputed value. There are two low level functions here, one to create an imputed series, e.g. forward impute from a response, and a second to apply the relevant rows to a `combined_imputation` column. The higher order function runs both these function for construction, forward from result, backward from result and forward from construction. 

To be able to use a generalised function for all imputation types there is an imputation config to handle the differences in implementation.

There is only one test to cover four cases in this pull request. More tests are recommended in future, however, refactoring of the function was required to get it to work for a single test case, so I just applied it to all cases. 

# Checklists

<!--
These are do-confirm checklists; it confirms that you have done each item.

If actions are irrelevant, please add a comment stating why.

Incomplete pull/merge requests may be blocked until actions are resolved, or closed at
the reviewers' discretion.
-->

This pull request meets the following requirements:

- [ ] installable with all dependencies recorded
- [x] runs without error
- [x] follows PEP8 and project specific conventions
- [x] appropriate use of comments, for example no descriptive comments
- [x] functions documented using Numpy style docstings
- [x] assumptions and decisions log considered and updated if appropriate
- [x] unit tests have been updated to cover essential functionality for a reasonable range of inputs and conditions
- [x] other forms of testing such as end-to-end and user-interface testing have been considered and updated as required
- [x] tests suite passes (locally as a minimum)
- [x] peer reviewed with review recorded

If you feel some of these conditions do not apply for this pull request, please
add a comment to explain why.
