### PR TITLE
333 pre calculated links

### DIFF
--- a/mbs_results/ratio_of_means.py
+++ b/mbs_results/ratio_of_means.py
@@ -132,8 +132,8 @@ def wrap_shift_by_strata_period(
         ),
     )
     
-    if ["f_link_question", "b_link_question", "construction_link"] in df.columns:
-        link_arguments = link_arguments[2]
+    if df.columns.isin(["f_link_question", "b_link_question", "construction_link"]).all():
+        link_arguments = link_arguments[2:]
 
     for args in link_arguments:
         df = shift_by_strata_period(df, **args)
@@ -281,7 +281,7 @@ def ratio_of_means(
     strata: str,
     auxiliary: str,
     filters: pd.DataFrame = None,
-    imputation_links: dict = None,
+    imputation_links: dict = {},
     **kwargs
 ) -> pd.DataFrame:
     """
@@ -338,11 +338,11 @@ def ratio_of_means(
     if filters is not None:
 
         df = flag_rows_to_ignore(df, filters)
-        
-    if ["f_link_question", "b_link_question", "construction_link"] in imputation_links.values():
+    
+    if all(links in imputation_links.values() for links in ["f_link_question", "b_link_question", "construction_link"]):
                 
         df = (
-            df.rename(columns=imputation_links, inplace=True)
+            df.rename(columns=imputation_links)
             .pipe(wrap_shift_by_strata_period, **default_columns)
         )
 

--- a/mbs_results/ratio_of_means.py
+++ b/mbs_results/ratio_of_means.py
@@ -311,7 +311,8 @@ def ratio_of_means(
     filters : pd.DataFrame, optional
         Dataframe with values to exclude from imputation method.
     imputation_links : dict, optional
-        Dictionary of column names matching to their imputation link type.
+        Dictionary of column name keys matching to their imputation link value
+        ("f_link_question", "b_link_question", "construction_link").
     kwargs : mapping, optional
         A dictionary of keyword arguments passed into func.
 

--- a/mbs_results/ratio_of_means.py
+++ b/mbs_results/ratio_of_means.py
@@ -281,7 +281,7 @@ def ratio_of_means(
     strata: str,
     auxiliary: str,
     filters: pd.DataFrame = None,
-    imputation_links: dict = {},
+    imputation_links: Dict[str, str] = {},
     **kwargs
 ) -> pd.DataFrame:
     """

--- a/mbs_results/ratio_of_means.py
+++ b/mbs_results/ratio_of_means.py
@@ -115,7 +115,7 @@ def wrap_shift_by_strata_period(
         df.loc[df["ignore_from_link"], "filtered_target"] = np.nan
 
         default_columns = {**default_columns, "target": "filtered_target"}
-        
+
     link_arguments = (
         dict(
             **default_columns,
@@ -131,8 +131,10 @@ def wrap_shift_by_strata_period(
             **{"time_difference": 1, "new_col": "f_predictive_auxiliary"}
         ),
     )
-    
-    if df.columns.isin(["f_link_question", "b_link_question", "construction_link"]).all():
+
+    if df.columns.isin(
+        ["f_link_question", "b_link_question", "construction_link"]
+    ).all():
         link_arguments = link_arguments[2:]
 
     for args in link_arguments:
@@ -339,22 +341,24 @@ def ratio_of_means(
     if filters is not None:
 
         df = flag_rows_to_ignore(df, filters)
-    
-    if all(links in imputation_links.values() for links in ["f_link_question", "b_link_question", "construction_link"]):
-                
-        df = (
-            df.rename(columns=imputation_links)
-            .pipe(wrap_shift_by_strata_period, **default_columns)
+
+    if all(
+        links in imputation_links.values()
+        for links in ["f_link_question", "b_link_question", "construction_link"]
+    ):
+
+        df = df.rename(columns=imputation_links).pipe(
+            wrap_shift_by_strata_period, **default_columns
         )
 
-    else: 
+    else:
 
         df = (
             df.pipe(wrap_flag_matched_pairs, **default_columns)
             .pipe(wrap_shift_by_strata_period, **default_columns)
             .pipe(wrap_calculate_imputation_link, **default_columns)
         )
-        
+
     df = (
         df.pipe(
             create_impute_flags,

--- a/tests/test_ratio_of_means.py
+++ b/tests/test_ratio_of_means.py
@@ -26,7 +26,7 @@ scenarios = [
     "16_BI_BI_R_NS_C_FI_FI",  # bug fixed ASAP-402
     "17_NS_R_FI_NS",
     "18_NS_BI_R_NS",
-    "19_link_columns",  #not yet implemented ASAP-333
+    "19_link_columns",
     "20_mixed_data",
     "21_class_change_R_C_FI",
     "22_class_change_C_BI_R",
@@ -35,7 +35,7 @@ scenarios = [
     "25_class_change_C_FI_FI",
     "26_C_FI_FI_NS_BI_BI_R_filtered",  # not yet implemented
     "27_BI_BI_R_NS_R_FI_FI_filtered",  # not yet implemented
-    '28_link_columns_filtered', #not yet implemented + ASAP-333
+    '28_link_columns_filtered',
     "29_mixed_data_filtered",  # not yet implemented
     "30_class_change_C_C_FI_filtered",  # not yet implemented
     "31_no_response",  # bug fixed ASAP-402

--- a/tests/test_ratio_of_means.py
+++ b/tests/test_ratio_of_means.py
@@ -35,7 +35,7 @@ scenarios = [
     "25_class_change_C_FI_FI",
     "26_C_FI_FI_NS_BI_BI_R_filtered",  # not yet implemented
     "27_BI_BI_R_NS_R_FI_FI_filtered",  # not yet implemented
-    '28_link_columns_filtered',
+    "28_link_columns_filtered",
     "29_mixed_data_filtered",  # not yet implemented
     "30_class_change_C_C_FI_filtered",  # not yet implemented
     "31_no_response",  # bug fixed ASAP-402
@@ -73,7 +73,7 @@ class TestRatioOfMeans:
             columns=["default_forward", "default_backward", "default_construction"]
         )
 
-        if base_file_name not in ["19_link_columns", '28_link_columns_filtered']:
+        if base_file_name not in ["19_link_columns", "28_link_columns_filtered"]:
             actual_output = ratio_of_means(
                 input_data,
                 target="question",
@@ -95,10 +95,10 @@ class TestRatioOfMeans:
                 imputation_links={
                     "forward": "f_link_question",
                     "backward": "b_link_question",
-                    "construction": "construction_link"
-                }
+                    "construction": "construction_link",
+                },
             )
-            
+
         # imputed_value is in a seperate column, remove this if otherwise
         actual_output["question"] = actual_output[["question", "imputed_value"]].agg(
             sum, axis=1

--- a/tests/test_ratio_of_means.py
+++ b/tests/test_ratio_of_means.py
@@ -73,17 +73,7 @@ class TestRatioOfMeans:
             columns=["default_forward", "default_backward", "default_construction"]
         )
 
-        if base_file_name not in ["19_link_columns", "28_link_columns_filtered"]:
-            actual_output = ratio_of_means(
-                input_data,
-                target="question",
-                period="date",
-                reference="identifier",
-                strata="group",
-                auxiliary="other",
-                filters=filter_df,
-            )
-        else:
+        if base_file_name in ["19_link_columns", "28_link_columns_filtered"]:
             actual_output = ratio_of_means(
                 input_data,
                 target="question",
@@ -97,6 +87,16 @@ class TestRatioOfMeans:
                     "backward": "b_link_question",
                     "construction": "construction_link",
                 },
+            )
+        else:
+            actual_output = ratio_of_means(
+                input_data,
+                target="question",
+                period="date",
+                reference="identifier",
+                strata="group",
+                auxiliary="other",
+                filters=filter_df,
             )
 
         # imputed_value is in a seperate column, remove this if otherwise

--- a/tests/test_ratio_of_means.py
+++ b/tests/test_ratio_of_means.py
@@ -26,7 +26,7 @@ scenarios = [
     "16_BI_BI_R_NS_C_FI_FI",  # bug fixed ASAP-402
     "17_NS_R_FI_NS",
     "18_NS_BI_R_NS",
-    # "19_link_columns",  #not yet implemented ASAP-333
+    "19_link_columns",  #not yet implemented ASAP-333
     "20_mixed_data",
     "21_class_change_R_C_FI",
     "22_class_change_C_BI_R",
@@ -35,7 +35,7 @@ scenarios = [
     "25_class_change_C_FI_FI",
     "26_C_FI_FI_NS_BI_BI_R_filtered",  # not yet implemented
     "27_BI_BI_R_NS_R_FI_FI_filtered",  # not yet implemented
-    # '28_link_columns_filtered', #not yet implemented + ASAP-333
+    '28_link_columns_filtered', #not yet implemented + ASAP-333
     "29_mixed_data_filtered",  # not yet implemented
     "30_class_change_C_C_FI_filtered",  # not yet implemented
     "31_no_response",  # bug fixed ASAP-402
@@ -73,16 +73,32 @@ class TestRatioOfMeans:
             columns=["default_forward", "default_backward", "default_construction"]
         )
 
-        actual_output = ratio_of_means(
-            input_data,
-            target="question",
-            period="date",
-            reference="identifier",
-            strata="group",
-            auxiliary="other",
-            filters=filter_df,
-        )
-
+        if base_file_name not in ["19_link_columns", '28_link_columns_filtered']:
+            actual_output = ratio_of_means(
+                input_data,
+                target="question",
+                period="date",
+                reference="identifier",
+                strata="group",
+                auxiliary="other",
+                filters=filter_df,
+            )
+        else:
+            actual_output = ratio_of_means(
+                input_data,
+                target="question",
+                period="date",
+                reference="identifier",
+                strata="group",
+                auxiliary="other",
+                filters=filter_df,
+                imputation_links={
+                    "forward": "f_link_question",
+                    "backward": "b_link_question",
+                    "construction": "construction_link"
+                }
+            )
+            
         # imputed_value is in a seperate column, remove this if otherwise
         actual_output["question"] = actual_output[["question", "imputed_value"]].agg(
             sum, axis=1


### PR DESCRIPTION
# Summary

Added parameter to the ratio_of_means() function which the user can use to select pre-calculated link columns. This will then skip imputation of the links in the pipeline.

# Checklists

<!--
These are do-confirm checklists; it confirms that you have done each item.

If actions are irrelevant, please add a comment stating why.

Incomplete pull/merge requests may be blocked until actions are resolved, or closed at
the reviewers' discretion.
-->

This pull request meets the following requirements:

- [ ] installable with all dependencies recorded
- [ ] runs without error
- [ ] follows PEP8 and project specific conventions
- [ ] appropriate use of comments, for example no descriptive comments
- [ ] functions documented using Numpy style docstings
- [ ] assumptions and decisions log considered and updated if appropriate
- [ ] unit tests have been updated to cover essential functionality for a reasonable range of inputs and conditions
- [ ] other forms of testing such as end-to-end and user-interface testing have been considered and updated as required
- [ ] tests suite passes (locally as a minimum)
- [ ] peer reviewed with review recorded
