### PR TITLE
485 rom manual construction input

### DIFF
--- a/mbs_results/data_cleaning.py
+++ b/mbs_results/data_cleaning.py
@@ -181,6 +181,49 @@ def load_manual_constructions(
         manual_constructions, on=[reference, period], how="outer", suffixes=("", "_man")
     )
 
+def join_manual_constructions(
+    df: pd.DataFrame, manual_constructions:pd.DataFrame, reference:str, period:str, **config
+):
+    """
+    function to change datatypes of columns based on config file
+
+    Parameters
+    ----------
+    df: pd.DataFrame
+        dataframe with combined responses and contributors columns
+        index is expected to be 'period' and 'reference'
+    manual_constructions_path: str
+        the manual construction dataframe
+    reference: str
+        the name of the reference column
+    period: str
+        the name of the period column
+    **config: Dict
+        main pipeline configuration. Can be used to input the entire config dictionary
+
+    Returns
+    -------
+    pd.DataFrame
+        dataframe with correctly formatted column datatypes.
+    """
+    if manual_constructions[period].dtype != df[period].dtype:
+        manual_constructions[period] = convert_column_to_datetime(
+            manual_constructions[period]
+        )
+    
+    if manual_constructions[reference].dtype != df[reference].dtype:
+        reference_dtype = df[reference].dtype
+        manual_constructions[reference] = manual_constructions[reference].astype(reference_dtype)
+
+    manual_constructions.set_index([reference, period], inplace=True)
+    df.set_index([reference, period], inplace=True)
+
+    validate_manual_constructions(df, manual_constructions)
+
+    return df.merge(
+        manual_constructions, on=[reference, period], how="outer", suffixes=("", "_man")
+    ).reset_index()
+
 
 def run_live_or_frozen(
     df: pd.DataFrame,
@@ -279,3 +322,5 @@ def create_imputation_class(
     )
 
     return df
+
+

--- a/mbs_results/data_cleaning.py
+++ b/mbs_results/data_cleaning.py
@@ -181,8 +181,13 @@ def load_manual_constructions(
         manual_constructions, on=[reference, period], how="outer", suffixes=("", "_man")
     )
 
+
 def join_manual_constructions(
-    df: pd.DataFrame, manual_constructions:pd.DataFrame, reference:str, period:str, **config
+    df: pd.DataFrame,
+    manual_constructions: pd.DataFrame,
+    reference: str,
+    period: str,
+    **config
 ):
     """
     function to change datatypes of columns based on config file
@@ -210,10 +215,12 @@ def join_manual_constructions(
         manual_constructions[period] = convert_column_to_datetime(
             manual_constructions[period]
         )
-    
+
     if manual_constructions[reference].dtype != df[reference].dtype:
         reference_dtype = df[reference].dtype
-        manual_constructions[reference] = manual_constructions[reference].astype(reference_dtype)
+        manual_constructions[reference] = manual_constructions[reference].astype(
+            reference_dtype
+        )
 
     manual_constructions.set_index([reference, period], inplace=True)
     df.set_index([reference, period], inplace=True)
@@ -232,7 +239,6 @@ def run_live_or_frozen(
     state: str = "live",
     error_values: List[str] = ["E", "W"],
 ) -> pd.DataFrame:
-
     """
     For frozen, therefore target values are converted to null, hence responses
     in error are treated as non-response.
@@ -322,5 +328,3 @@ def create_imputation_class(
     )
 
     return df
-
-

--- a/mbs_results/ratio_of_means.py
+++ b/mbs_results/ratio_of_means.py
@@ -11,7 +11,7 @@ from mbs_results.flag_and_count_matched_pairs import flag_matched_pair
 from mbs_results.imputation_flags import generate_imputation_marker
 from mbs_results.link_filter import flag_rows_to_ignore
 from mbs_results.predictive_variable import shift_by_strata_period
-
+from mbs_results.data_cleaning import join_manual_constructions
 
 def wrap_flag_matched_pairs(
     df: pd.DataFrame, **default_columns: Dict[str, str]
@@ -224,6 +224,7 @@ def ratio_of_means(
     strata: str,
     auxiliary: str,
     filters: pd.DataFrame = None,
+    manual_constructions: pd.DataFrame = None,
     imputation_links: Dict[str, str] = {},
     **kwargs,
 ) -> pd.DataFrame:
@@ -253,6 +254,8 @@ def ratio_of_means(
         Column name containing auxiliary information (sic).
     filters : pd.DataFrame, optional
         Dataframe with values to exclude from imputation method.
+    manual_constructions : pd.DataFrame, optional
+        Dataframe with values which are used for manual construction
     imputation_links : dict, optional
         Dictionary of column name keys matching to their imputation link value
         ("f_link_question", "b_link_question", "construction_link").
@@ -299,6 +302,11 @@ def ratio_of_means(
             .pipe(wrap_shift_by_strata_period, **default_columns)
             .pipe(wrap_calculate_imputation_link, **default_columns)
         )
+
+    if manual_constructions is not None:
+        # Need to join mc dataframe to original df
+        df = join_manual_constructions(df, manual_constructions, reference, period)
+
 
     if f"{target}_man" in df.columns:
         # Manual Construction

--- a/mbs_results/ratio_of_means.py
+++ b/mbs_results/ratio_of_means.py
@@ -7,11 +7,12 @@ from mbs_results.apply_imputation_link import create_and_merge_imputation_values
 from mbs_results.calculate_imputation_link import calculate_imputation_link
 from mbs_results.construction_matches import flag_construction_matches
 from mbs_results.cumulative_imputation_links import get_cumulative_links
+from mbs_results.data_cleaning import join_manual_constructions
 from mbs_results.flag_and_count_matched_pairs import flag_matched_pair
 from mbs_results.imputation_flags import generate_imputation_marker
 from mbs_results.link_filter import flag_rows_to_ignore
 from mbs_results.predictive_variable import shift_by_strata_period
-from mbs_results.data_cleaning import join_manual_constructions
+
 
 def wrap_flag_matched_pairs(
     df: pd.DataFrame, **default_columns: Dict[str, str]
@@ -306,7 +307,6 @@ def ratio_of_means(
     if manual_constructions is not None:
         # Need to join mc dataframe to original df
         df = join_manual_constructions(df, manual_constructions, reference, period)
-
 
     if f"{target}_man" in df.columns:
         # Manual Construction

--- a/tests/test_ratio_of_means.py
+++ b/tests/test_ratio_of_means.py
@@ -182,33 +182,40 @@ class TestRatioOfMeans:
         assert_frame_equal(actual_output, expected_output, check_dtype=False)
 
 
+pytestmark = pytest.mark.parametrize(
+    "base_file_name", scenarios[len(scenarios) - 10 : len(scenarios)]
+)
 
-pytestmark = pytest.mark.parametrize("base_file_name", scenarios[len(scenarios)-10:len(scenarios)])
+
 class TestRatioOfMeansManConstruction:
-    def test_manual_construction_input(self,base_file_name):
-        df = pd.read_csv(scenario_path_prefix + "ratio_of_means/" + base_file_name + "_input.csv")
-        expected_output = pd.read_csv(scenario_path_prefix + "ratio_of_means/" + base_file_name + "_output.csv")
+    def test_manual_construction_input(self, base_file_name):
+        df = pd.read_csv(
+            scenario_path_prefix + "ratio_of_means/" + base_file_name + "_input.csv"
+        )
+        expected_output = pd.read_csv(
+            scenario_path_prefix + "ratio_of_means/" + base_file_name + "_output.csv"
+        )
 
         manual_constructions = df.copy()[["identifier", "date", "question_man"]]
-        manual_constructions.rename(columns={"question_man":"question"},inplace=True)
+        manual_constructions.rename(columns={"question_man": "question"}, inplace=True)
 
-        df.drop(columns = ["question_man"],inplace=True)
+        df.drop(columns=["question_man"], inplace=True)
         input_data = df
-        input_data["date"] = convert_column_to_datetime(
-        input_data["date"]
-    )
-        
-        manual_constructions["date"] = convert_column_to_datetime(manual_constructions["date"])
+        input_data["date"] = convert_column_to_datetime(input_data["date"])
+
+        manual_constructions["date"] = convert_column_to_datetime(
+            manual_constructions["date"]
+        )
 
         actual_output = ratio_of_means(
-                input_data,
-                target="question",
-                period="date",
-                reference="identifier",
-                strata="group",
-                auxiliary="other",
-                manual_constructions= manual_constructions
-            )
+            input_data,
+            target="question",
+            period="date",
+            reference="identifier",
+            strata="group",
+            auxiliary="other",
+            manual_constructions=manual_constructions,
+        )
         actual_output["question"] = actual_output[["question", "imputed_value"]].agg(
             sum, axis=1
         )
@@ -271,10 +278,15 @@ class TestRatioOfMeansManConstruction:
             "imputation_flags_question"
         ].str.lower()
         expected_output = expected_output.replace({"bi": "bir"})
-        
-        expected_output["f_match_question_pair_count"] = expected_output["f_match_question_pair_count"].astype(float)
-        expected_output["b_match_question_pair_count"] = expected_output["b_match_question_pair_count"].astype(float)
-        expected_output["flag_match_pair_count"] = expected_output["flag_match_pair_count"].astype(float)
+
+        expected_output["f_match_question_pair_count"] = expected_output[
+            "f_match_question_pair_count"
+        ].astype(float)
+        expected_output["b_match_question_pair_count"] = expected_output[
+            "b_match_question_pair_count"
+        ].astype(float)
+        expected_output["flag_match_pair_count"] = expected_output[
+            "flag_match_pair_count"
+        ].astype(float)
 
         assert_frame_equal(expected_output, actual_output)
-


### PR DESCRIPTION
# Summary

Extended Ratio of Means functionality to take manual construction df as an optional input. 
Manual construction can also be triggered if there is a manual construction column present in the original data frame as well (should this be the case or removed)
Performs some validation checks in the joining function. 
closes #68 

# Checklists

<!--
These are do-confirm checklists; it confirms that you have done each item.

If actions are irrelevant, please add a comment stating why.

Incomplete pull/merge requests may be blocked until actions are resolved, or closed at
the reviewers' discretion.
-->

This pull request meets the following requirements:

- [x] installable with all dependencies recorded
- [x] runs without error
- [x] follows PEP8 and project specific conventions
- [x] appropriate use of comments, for example no descriptive comments
- [x] functions documented using Numpy style docstings
- [x] assumptions and decisions log considered and updated if appropriate
- [x] unit tests have been updated to cover essential functionality for a reasonable range of inputs and conditions
- [x] other forms of testing such as end-to-end and user-interface testing have been considered and updated as required
- [x] tests suite passes (locally as a minimum)
- [ ] peer reviewed with review recorded

If you feel some of these conditions do not apply for this pull request, please
add a comment to explain why.
