### PR TITLE
Combine adjusted and imputed values to one column

### DIFF
--- a/testing_helpers.py
+++ b/testing_helpers.py
@@ -135,13 +135,13 @@ def get_qa_output_482(post_win_df):
         'default_link_f_match_adjusted_value','b_link_adjusted_value',
         'b_match_adjusted_value_pair_count','default_link_b_match_adjusted_value',
         'construction_link', 'flag_construction_matches_pair_count','default_link_flag_construction_matches',
-        "imputed_value","constrain_marker" # these not requested but usefull
+        "constrain_marker" # these not requested but usefull
         ]
 
     # not part of the pipeline the below
     post_win_df['total weight (A*G*O)'] = post_win_df['design_weight']*post_win_df['calibration_factor']*post_win_df['outlier_weight']
     
-    post_win_df['weighted adjusted value'] =post_win_df['imputed_value'] * post_win_df['total weight (A*G*O)']
+    post_win_df['weighted adjusted value'] =post_win_df['adjusted_value'] * post_win_df['total weight (A*G*O)']
 
 
     return post_win_df[requested_columns]

--- a/testing_main.py
+++ b/testing_main.py
@@ -54,6 +54,13 @@ if __name__ == "__main__":
     
     post_constrain = constrain(post_impute,"period","reference","adjusted_value","imputed_value","question_no","form_type_spp")
 
+    # Winsorise and outputs expect return value and impute to be on same column
+    post_constrain["adjusted_value"] = post_constrain[["adjusted_value", "imputed_value"]].agg(
+            sum, axis=1) 
+            
+    post_constrain.drop(columns=["imputed_value"], inplace=True)
+
+
     check_na_duplicates(post_constrain) #just basic check
 
     # Imputation test data here


### PR DESCRIPTION
# Summary
Winsorise and outputs expect adjusted values and imputed values to be on the same column, this pull request aims to fix for the testing outputs.

