### PR TITLE
494 combine imputed adjusted

### DIFF
--- a/mbs_results/estimation/apply_imputation_link.py
+++ b/mbs_results/estimation/apply_imputation_link.py
@@ -4,7 +4,6 @@ def create_and_merge_imputation_values(
     reference,
     period,
     marker,
-    combined_imputation,
     target,
     cumulative_forward_link,
     cumulative_backward_link,
@@ -103,7 +102,7 @@ def create_and_merge_imputation_values(
             # if manual construction imputation is done
             "intermediate_column": "fic",
             "marker": "fic",
-            "fill_column": "imputed_value",
+            "fill_column": target,
             "fill_method": "ffill",
             "link_column": cumulative_forward_link,
         },
@@ -117,9 +116,7 @@ def create_and_merge_imputation_values(
         df = create_impute(
             df, [imputation_class, reference], imputation_config[imp_type]
         )
-        df = merge_imputation_type(
-            df, imputation_config[imp_type], marker, combined_imputation
-        )
+        df = merge_imputation_type(df, imputation_config[imp_type], marker, target)
 
         intermediate_columns.append(imputation_config[imp_type]["intermediate_column"])
 
@@ -154,7 +151,7 @@ def create_impute(df, group, imputation_spec):
     return df
 
 
-def merge_imputation_type(df, imputation_spec, marker, combined_imputation):
+def merge_imputation_type(df, imputation_spec, marker, target):
     """
     Uses an existing column of imputed values and a imputation marker to merge values
     into a single column
@@ -178,5 +175,5 @@ def merge_imputation_type(df, imputation_spec, marker, combined_imputation):
     imputation_marker = imputation_spec["marker"]
     imputation_column = imputation_spec["intermediate_column"]
 
-    df.loc[df[marker] == imputation_marker, combined_imputation] = df[imputation_column]
+    df.loc[df[marker] == imputation_marker, target] = df[imputation_column]
     return df

--- a/mbs_results/imputation/ratio_of_means.py
+++ b/mbs_results/imputation/ratio_of_means.py
@@ -380,6 +380,7 @@ def ratio_of_means(
     )
 
     df[target] = df[[target, "imputed_value"]].agg(sum, axis=1)
+    df.drop(columns = "imputed_value",inplace=True)
 
     # TODO: Missing extra columns, default values and if filter was applied, all bool
 

--- a/mbs_results/imputation/ratio_of_means.py
+++ b/mbs_results/imputation/ratio_of_means.py
@@ -379,6 +379,8 @@ def ratio_of_means(
         errors="ignore",
     )
 
+    df[target] = df[[target, "imputed_value"]].agg(sum, axis=1)
+
     # TODO: Missing extra columns, default values and if filter was applied, all bool
 
     return df

--- a/mbs_results/imputation/ratio_of_means.py
+++ b/mbs_results/imputation/ratio_of_means.py
@@ -380,7 +380,7 @@ def ratio_of_means(
     )
 
     df[target] = df[[target, "imputed_value"]].agg(sum, axis=1)
-    df.drop(columns = "imputed_value",inplace=True)
+    df.drop(columns="imputed_value", inplace=True)
 
     # TODO: Missing extra columns, default values and if filter was applied, all bool
 

--- a/mbs_results/imputation/ratio_of_means.py
+++ b/mbs_results/imputation/ratio_of_means.py
@@ -331,7 +331,6 @@ def ratio_of_means(
             **default_columns,
             imputation_class=strata,
             marker=f"imputation_flags_{target}",
-            combined_imputation="imputed_value",
             cumulative_forward_link="cumulative_f_link_" + target,
             cumulative_backward_link="cumulative_b_link_" + target,
             construction_link="construction_link",
@@ -378,9 +377,6 @@ def ratio_of_means(
         axis=1,
         errors="ignore",
     )
-
-    df[target] = df[[target, "imputed_value"]].agg(sum, axis=1)
-    df.drop(columns="imputed_value", inplace=True)
 
     # TODO: Missing extra columns, default values and if filter was applied, all bool
 

--- a/mbs_results/outputs/selective_editing_question_output.py
+++ b/mbs_results/outputs/selective_editing_question_output.py
@@ -1,10 +1,7 @@
 import pandas as pd
 
 from mbs_results.merge_domain import merge_domain
-from mbs_results.unsorted.selective_editing import (
-    calculate_predicted_value,
-    create_standardising_factor,
-)
+from mbs_results.unsorted.selective_editing import create_standardising_factor
 
 
 def create_selective_editing_question_output(
@@ -18,7 +15,6 @@ def create_selective_editing_question_output(
     a_weight: str,
     o_weight: str,
     g_weight: str,
-    imputed_value: str,
     adjusted_value: str,
     sic_domain_mapping_path: str,
     period_selected: int,
@@ -49,10 +45,9 @@ def create_selective_editing_question_output(
          column name containing the outlier weight.
      g_weight : str
          column name containing the g weight.
-     imputed_value : str
-         name of column in dataframe containing imputed_value variable
      adjusted_value : str
-         name of column in dataframe containing adjusted_value variable
+         name of column in dataframe containing adjusted_value variable combined
+         with imputed_values as outputted from Ratio of Means script
     sic_domain_mapping_path : str
          path to the sic domain mapping file
      period_selected : int
@@ -77,7 +72,6 @@ def create_selective_editing_question_output(
      >>            a_weight="design_weight",
      >>            o_weight="outlier_weight",
      >>            g_weight="calibration_factor",
-     >>            imputed_value="imputed_value",
      >>            adjusted_value="adjusted_value",
      >>            sic_domain_mapping_path="mapping_files/sic_domain_mapping.csv",
      >>            period_selected=202201,
@@ -92,19 +86,13 @@ def create_selective_editing_question_output(
         sic_mapping="sic_5_digit",
     )
 
-    df_with_domain = calculate_predicted_value(
-        dataframe=df_with_domain,
-        imputed_value=imputed_value,
-        adjusted_value=adjusted_value,
-    )
-
     standardising_factor = create_standardising_factor(
         dataframe=df_with_domain,
         reference=reference,
         period=period,
         domain=domain,
         question_no=question_no,
-        predicted_value="predicted_value",
+        predicted_value=adjusted_value,
         imputation_marker="imputation_flags_adjusted_value",
         a_weight=a_weight,
         o_weight=o_weight,

--- a/mbs_results/unsorted/constrains.py
+++ b/mbs_results/unsorted/constrains.py
@@ -375,9 +375,9 @@ def calculate_derived_outlier_weights(
     )
 
     updated_o_weight_bool = df_pre_winsorised[winsorised_target].isna()
-    df_pre_winsorised.loc[updated_o_weight_bool, winsorised_target] = (
-        post_win_derived.loc[updated_o_weight_bool, winsorised_target]
-    )
+    df_pre_winsorised.loc[
+        updated_o_weight_bool, winsorised_target
+    ] = post_win_derived.loc[updated_o_weight_bool, winsorised_target]
     df_pre_winsorised["post_wins_marker"] = updated_o_weight_bool
 
     df_pre_winsorised.reset_index(inplace=True)

--- a/mbs_results/unsorted/constrains.py
+++ b/mbs_results/unsorted/constrains.py
@@ -103,7 +103,6 @@ def constrain(
     period: str,
     reference: str,
     target: str,
-    target_imputed: str,
     question_no: str,
     spp_form_id: str,
 ) -> pd.DataFrame:
@@ -130,9 +129,7 @@ def constrain(
     reference : str
         Column name containing reference.
     target : str
-        Column name containing target value.
-    target_imputed : str
-        Column name containing imputed target value.
+        Column name containing target value and imputed values.
     question_no : str
         Column name containing question number.
     spp_form_id : str
@@ -156,19 +153,19 @@ def constrain(
             reference,
             "cell_no",
             "frotover",
-            "froempment",
+            "froempees",
             "form_type",
             "response_type",
         ],
         verify_integrity=False,
     )
-    pre_derive_df = pre_derive_df[[target, target_imputed]]
+    pre_derive_df = pre_derive_df[[target]]
 
     derived_values = pd.concat(
         [
-            sum_sub_df(pre_derive_df.loc[form_type], derives["from"]).assign(
-                **{question_no: derives["derive"]}
-            )
+            sum_sub_df(pre_derive_df.loc[form_type], derives["from"])
+            .assign(**{question_no: derives["derive"]})
+            .assign(**{spp_form_id: form_type})
             for form_type, derives in derive_map.items()
         ]
     )
@@ -176,9 +173,9 @@ def constrain(
     df.set_index([question_no, period, reference], inplace=True)
 
     if 49 in unique_q_numbers:
-        replace_values_index_based(df, target_imputed, 49, ">", 40)
+        replace_values_index_based(df, target, 49, ">", 40)
     elif 90 in unique_q_numbers:
-        replace_values_index_based(df, target_imputed, 90, ">=", 40)
+        replace_values_index_based(df, target, 90, ">=", 40)
 
     df.reset_index(inplace=True)
 

--- a/mbs_results/unsorted/constrains.py
+++ b/mbs_results/unsorted/constrains.py
@@ -375,9 +375,9 @@ def calculate_derived_outlier_weights(
     )
 
     updated_o_weight_bool = df_pre_winsorised[winsorised_target].isna()
-    df_pre_winsorised.loc[
-        updated_o_weight_bool, winsorised_target
-    ] = post_win_derived.loc[updated_o_weight_bool, winsorised_target]
+    df_pre_winsorised.loc[updated_o_weight_bool, winsorised_target] = (
+        post_win_derived.loc[updated_o_weight_bool, winsorised_target]
+    )
     df_pre_winsorised["post_wins_marker"] = updated_o_weight_bool
 
     df_pre_winsorised.reset_index(inplace=True)

--- a/mbs_results/unsorted/constrains.py
+++ b/mbs_results/unsorted/constrains.py
@@ -153,7 +153,7 @@ def constrain(
             reference,
             "cell_no",
             "frotover",
-            "froempees",
+            "froempment",
             "form_type",
             "response_type",
         ],

--- a/tests/data/apply_imputation_link/FIR_BIR_C_FIC.csv
+++ b/tests/data/apply_imputation_link/FIR_BIR_C_FIC.csv
@@ -1,10 +1,10 @@
-imputation_class,reference,target,period,forward_imputation_link,backward_imputation_link,auxiliary_variable,construction_link,cumulative_forward_link,cumulative_backward_link,imputation_marker,imputed_value
-100,100000,200,202402,1,2,,,,,r,
+imputation_class,reference,target,period,forward_imputation_link,backward_imputation_link,auxiliary_variable,construction_link,cumulative_forward_link,cumulative_backward_link,imputation_marker,expected_target
+100,100000,200,202402,1,2,,,,,r,200
 100,100000,,202403,2,0.6,,,2,0.6,fir,400
 100,100000,,202404,3,1,,,6,1,fir,1200
 200,100001,,202402,1,4,,,1,2,bir,600
 200,100001,,202403,3,0.5,,,3,0.5,bir,150
-200,100001,300,202404,0.5,1,,,,,r,
+200,100001,300,202404,0.5,1,,,,,r,300
 300,100002,,202402,1,4,1000,0.1,,2,c,100
 300,100002,,202403,3,0.5,,,3,0.5,fic,300
 300,100002,,202404,0.5,1,,,1.5,,fic,150

--- a/tests/data/apply_imputation_link/MC_FIMC.csv
+++ b/tests/data/apply_imputation_link/MC_FIMC.csv
@@ -1,10 +1,10 @@
-﻿imputation_class,reference,target,period,target_man,forward_imputation_link,backward_imputation_link,auxiliary_variable,construction_link,cumulative_forward_link,cumulative_backward_link,imputation_marker,imputed_value
-100,100000,200,202402,,1,2,,,,,r,
+﻿imputation_class,reference,target,period,target_man,forward_imputation_link,backward_imputation_link,auxiliary_variable,construction_link,cumulative_forward_link,cumulative_backward_link,imputation_marker,expected_target
+100,100000,200,202402,,1,2,,,,,r,200
 100,100000,,202403,,2,0.6,,,2,0.6,fir,400
 100,100000,,202404,,3,1,,,6,1,fir,1200
 200,100001,,202402,,1,4,,,1,2,bir,600
 200,100001,,202403,,3,0.5,,,3,0.5,bir,150
-200,100001,300,202404,,0.5,1,,,,,r,
+200,100001,300,202404,,0.5,1,,,,,r,300
 300,100002,,202402,,1,4,1000,0.1,,2,c,100
 300,100002,,202403,,3,0.5,,,3,0.5,fic,300
 300,100002,,202404,,0.5,1,,,1.5,,fic,150

--- a/tests/test_estimation/test_apply_imputation_link.py
+++ b/tests/test_estimation/test_apply_imputation_link.py
@@ -34,7 +34,6 @@ class TestApplyImputationLink:
             "reference",
             "period",
             "imputation_marker",
-            "imputed_value",
             "target",
             "cumulative_forward_link",
             "cumulative_backward_link",
@@ -42,6 +41,10 @@ class TestApplyImputationLink:
             "construction_link",
             imputation_types=("c", "fir", "bir", "fic"),
         )
+        expected_output["target"] = expected_output[["target", "imputed_value"]].agg(
+            sum, axis=1
+        )
+        expected_output.drop(columns="imputed_value", inplace=True)
 
         assert_frame_equal(actual_output, expected_output)
 
@@ -56,7 +59,6 @@ class TestApplyImputationLink:
             "reference",
             "period",
             "imputation_marker",
-            "imputed_value",
             "target",
             "cumulative_forward_link",
             "cumulative_backward_link",
@@ -65,5 +67,9 @@ class TestApplyImputationLink:
             imputation_types=("c", "mc", "fir", "bir", "fimc", "fic"),
         )
         actual_output.drop(columns=["man_link"], inplace=True)
+        expected_output["target"] = expected_output[["target", "imputed_value"]].agg(
+            sum, axis=1
+        )
+        expected_output.drop(columns="imputed_value", inplace=True)
 
         assert_frame_equal(actual_output, expected_output)

--- a/tests/test_estimation/test_apply_imputation_link.py
+++ b/tests/test_estimation/test_apply_imputation_link.py
@@ -25,9 +25,14 @@ def mc_fimc_test_data():
 
 class TestApplyImputationLink:
     def test_all_imputation_types(self, fir_bir_c_fic_test_data):
-        expected_output = fir_bir_c_fic_test_data
+        loaded_data = fir_bir_c_fic_test_data
 
-        input_data = expected_output.drop(columns=["imputed_value"])
+        input_data = loaded_data.drop(columns=["expected_target"])
+        expected_output = loaded_data.drop(columns="target").rename(
+            columns={"expected_target": "target"}
+        )
+        expected_output["target"] = expected_output["target"].astype(float)
+
         actual_output = create_and_merge_imputation_values(
             input_data,
             "imputation_class",
@@ -41,18 +46,22 @@ class TestApplyImputationLink:
             "construction_link",
             imputation_types=("c", "fir", "bir", "fic"),
         )
-        expected_output["target"] = expected_output[["target", "imputed_value"]].agg(
-            sum, axis=1
-        )
-        expected_output.drop(columns="imputed_value", inplace=True)
 
+        actual_output = actual_output.sort_index(axis=1)
+        expected_output = expected_output.sort_index(axis=1)
         assert_frame_equal(actual_output, expected_output)
 
     def test_mc_imputation_types(self, mc_fimc_test_data):
-        expected_output = mc_fimc_test_data
+        loaded_data = mc_fimc_test_data
 
-        input_data = expected_output.drop(columns=["imputed_value"])
+        input_data = loaded_data.drop(columns=["expected_target"])
         input_data["man_link"] = 1
+
+        expected_output = loaded_data.drop(columns="target").rename(
+            columns={"expected_target": "target"}
+        )
+        expected_output["target"] = expected_output["target"].astype(float)
+
         actual_output = create_and_merge_imputation_values(
             input_data,
             "imputation_class",
@@ -67,9 +76,8 @@ class TestApplyImputationLink:
             imputation_types=("c", "mc", "fir", "bir", "fimc", "fic"),
         )
         actual_output.drop(columns=["man_link"], inplace=True)
-        expected_output["target"] = expected_output[["target", "imputed_value"]].agg(
-            sum, axis=1
-        )
-        expected_output.drop(columns="imputed_value", inplace=True)
+
+        actual_output = actual_output.sort_index(axis=1)
+        expected_output = expected_output.sort_index(axis=1)
 
         assert_frame_equal(actual_output, expected_output)

--- a/tests/test_imputation/test_ratio_of_means.py
+++ b/tests/test_imputation/test_ratio_of_means.py
@@ -105,10 +105,6 @@ class TestRatioOfMeans:
                 filters=filter_df,
             )
 
-        # imputed_value is in a separate column, remove this if otherwise
-        actual_output["question"] = actual_output[["question", "imputed_value"]].agg(
-            sum, axis=1
-        )
         actual_output = actual_output.rename(
             columns={
                 "default_link_b_match_question": "default_backward",
@@ -133,14 +129,6 @@ class TestRatioOfMeans:
                 "count_construction": "flag_match_pair_count",
             }
         )
-
-        # expected_output = expected_output.drop(
-        #     columns=[
-        #         "f_matched_pair_count",
-        #         "b_matched_pair_count",
-        #         "flag_matched_pair_count",
-        #     ]
-        # )
 
         actual_output.drop(columns=["question_man"], errors="ignore", inplace=True)
         # Temp work around to drop mc column until its fully integrated
@@ -218,9 +206,7 @@ class TestRatioOfMeansManConstruction:
             auxiliary="other",
             manual_constructions=manual_constructions,
         )
-        actual_output["question"] = actual_output[["question", "imputed_value"]].agg(
-            sum, axis=1
-        )
+
         expected_output["date"] = convert_column_to_datetime(expected_output["date"])
         actual_output = actual_output.rename(
             columns={

--- a/tests/test_imputation/test_ratio_of_means.py
+++ b/tests/test_imputation/test_ratio_of_means.py
@@ -114,7 +114,7 @@ class TestRatioOfMeans:
             }
         )
 
-        actual_output = actual_output.drop(columns=["imputed_value", "other"])
+        actual_output = actual_output.drop(columns=["other"])
 
         # if stays like this we need a function to load expected data
         expected_output = expected_output.rename(
@@ -217,7 +217,7 @@ class TestRatioOfMeansManConstruction:
             }
         )
 
-        actual_output = actual_output.drop(columns=["imputed_value", "other"])
+        actual_output = actual_output.drop(columns=["other"])
 
         # if stays like this we need a function to load expected data
         expected_output = expected_output.rename(


### PR DESCRIPTION
# Summary

Changes to RoM script to combine imputed and adjusted values into one column. They are combined into adjusted_value
Other changes have been made to lower level functions to reflect this early change

# Checklists

<!--
These are do-confirm checklists; it confirms that you have done each item.

If actions are irrelevant, please add a comment stating why.

Incomplete pull/merge requests may be blocked until actions are resolved, or closed at
the reviewers' discretion.
-->

This pull request meets the following requirements:

- [ ] installable with all dependencies recorded
- [ ] runs without error
- [ ] follows PEP8 and project specific conventions
- [ ] appropriate use of comments, for example no descriptive comments
- [ ] functions documented using Numpy style docstings
- [ ] assumptions and decisions log considered and updated if appropriate
- [ ] unit tests have been updated to cover essential functionality for a reasonable range of inputs and conditions
- [ ] other forms of testing such as end-to-end and user-interface testing have been considered and updated as required
- [ ] tests suite passes (locally as a minimum)
- [ ] peer reviewed with review recorded

If you feel some of these conditions do not apply for this pull request, please
add a comment to explain why.
