### PR TITLE
603 update project python version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 // Global scope required for multi-stage persistence
 def artServer = Artifactory.server "art-p-01"
 def buildInfo = Artifactory.newBuildInfo()
-def agentPython3Version = 'python_3.6.1'
+def agentPython3Version = 'python_3.10'
 
 
 def pushToPyPiArtifactoryRepo(String projectName, String sourceDist = 'dist/*', String artifactoryHost = 'art-p-01') {
@@ -60,7 +60,8 @@ pipeline {
             steps {
                 unstash name: 'Checkout'
                 colourText('info', "Building package")
-                sh 'pip3 install wheel==0.29.0'
+                sh 'pip3 install setuptools'
+                sh 'pip3 install wheel'
                 sh 'python3 setup.py build bdist_wheel'
                 stash name: "Build", useDefaultExcludes: false
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,8 +25,8 @@ pipeline {
         PROXY = credentials("PROXY")  // Http proxy address, set in Jenkins Credentials
         ARTIFACTORY_CREDS = "ARTIFACTORY_CREDENTIALS"
         ARTIFACTORY_PYPI_REPO = "LR_mbs-results"
-        BUILD_BRANCH = "603-Update-project-Python-version"
-        BUILD_TAG = "*"
+        BUILD_BRANCH = "main"
+        BUILD_TAG = "v*.*.*"
     }
 
     // Don't use default checkout process, as we define it as a stage below

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,8 +25,8 @@ pipeline {
         PROXY = credentials("PROXY")  // Http proxy address, set in Jenkins Credentials
         ARTIFACTORY_CREDS = "ARTIFACTORY_CREDENTIALS"
         ARTIFACTORY_PYPI_REPO = "LR_mbs-results"
-        BUILD_BRANCH = "main"
-        BUILD_TAG = "v*"
+        BUILD_BRANCH = "603-Update-project-Python-version"
+        BUILD_TAG = "*"
     }
 
     // Don't use default checkout process, as we define it as a stage below

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,8 +25,8 @@ pipeline {
         PROXY = credentials("PROXY")  // Http proxy address, set in Jenkins Credentials
         ARTIFACTORY_CREDS = "ARTIFACTORY_CREDENTIALS"
         ARTIFACTORY_PYPI_REPO = "LR_mbs-results"
-        BUILD_BRANCH = "main"
-        BUILD_TAG = "v*.*.*"
+        BUILD_BRANCH = "main" // only deploy from this/these branches
+        BUILD_TAG = "v*.*.*" // only deploy with a commit message tagged like v0.0.1
     }
 
     // Don't use default checkout process, as we define it as a stage below

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,8 +25,8 @@ pipeline {
         PROXY = credentials("PROXY")  // Http proxy address, set in Jenkins Credentials
         ARTIFACTORY_CREDS = "ARTIFACTORY_CREDENTIALS"
         ARTIFACTORY_PYPI_REPO = "LR_mbs-results"
-        BUILD_BRANCH = "603-Update-project-Python-version"
-        BUILD_TAG = "*"
+        BUILD_BRANCH = "main"
+        BUILD_TAG = "v*"
     }
 
     // Don't use default checkout process, as we define it as a stage below

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pandas
+pandas==1.1.5
 numpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pandas==1.1.5
+pandas
 numpy


### PR DESCRIPTION
# Summary

This pull request is to update the Python version in the Jenkinsfile so that Jenkins can build the package and deploy to Artifactory. 

I have tested the workflow since making the changes and Jenkins is now able to build the package using Python 3.10. There is now a version 0.0.3 on Artifactory of the mbs-results package. However, this package does not install an environment using Python 3.9 or higher because of the forced version of pandas in the project requirements.txt. Therefore the forced version of pandas has been removed as part of this pull request. After it is merged when we create the next version of the package it will be built with a higher version of pandas and should work with supported versions of Python. 

# Checklists

<!--
These are do-confirm checklists; it confirms that you have done each item.

If actions are irrelevant, please add a comment stating why.

Incomplete pull/merge requests may be blocked until actions are resolved, or closed at
the reviewers' discretion.
-->

This pull request meets the following requirements:

- [ ] installable with all dependencies recorded
- [ ] follows PEP8 and project specific conventions
- [ ] appropriate use of comments, for example no descriptive comments
- [ ] tests suite passes (locally as a minimum)
- [ ] peer reviewed with review recorded

If you feel some of these conditions do not apply for this pull request, please
add a comment to explain why.
