### PR TITLE
Adding user ability to setup config.json and main.py when running the package in CML

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include mbs_results/config.json

--- a/mbs_results/start.py
+++ b/mbs_results/start.py
@@ -1,14 +1,14 @@
 import os
 import shutil
 
-def move_files():
+def move_files(mbs_results_install_location):
     """
     Copy mbs_results/main.py and mbs_results/config.json from
     virtual environment site packages into the current working directory
     """
 
     # Get the directory where mbs_results is installed
-    target_path = os.path.dirname(mbs_results.__file__)
+    target_path = os.path.dirname(mbs_results_install_location)
 
     # Append main.py and config.json
     main_path = os.path.join(target_path, "main.py")

--- a/mbs_results/start.py
+++ b/mbs_results/start.py
@@ -1,14 +1,20 @@
 import os
 import shutil
 
-def move_files(mbs_results_install_location):
+def move_files(installPath: str):
     """
     Copy mbs_results/main.py and mbs_results/config.json from
     virtual environment site packages into the current working directory
+
+    Parameters
+    ----------
+    installPath : str 
+        Where the the mbs_results package is installed locally, e.g., mbs_results.__file__
+    
     """
 
     # Get the directory where mbs_results is installed
-    target_path = os.path.dirname(mbs_results_install_location)
+    target_path = os.path.dirname(installPath)
 
     # Append main.py and config.json
     main_path = os.path.join(target_path, "main.py")

--- a/mbs_results/start.py
+++ b/mbs_results/start.py
@@ -9,8 +9,17 @@ def move_files(installPath: str):
     Parameters
     ----------
     installPath : str 
-        Where the the mbs_results package is installed locally, e.g., mbs_results.__file__
-    
+        Where the the mbs_results package is installed locally. 
+        E.g., mbs_results.__file__
+
+    Examples
+    ---------
+    >>> import mbs_results
+    ...
+    >>> from mbs_results.start import move_files
+    ...
+    >>> move_files(mbs_results.__file__)
+
     """
 
     # Get the directory where mbs_results is installed

--- a/mbs_results/start.py
+++ b/mbs_results/start.py
@@ -1,0 +1,22 @@
+import os
+import shutil
+
+def move_files():
+    """
+    Copy mbs_results/main.py and mbs_results/config.json from
+    virtual environment site packages into the current working directory
+    """
+
+    # Get the directory where mbs_results is installed
+    target_path = os.path.dirname(mbs_results.__file__)
+
+    # Append main.py and config.json
+    main_path = os.path.join(target_path, "main.py")
+    config_path = os.path.join(target_path, "config.json")
+
+    # Get the destination for the copy
+    working_directory = os.getcwd()
+
+    # Copy the files
+    shutil.copy(main_path, working_directory)
+    shutil.copy(config_path, working_directory)

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,8 +12,15 @@ classifiers =
     Programming Language :: Python :: 3.9
 
 [options]
-packages =
+packages = 
     mbs_results
+    mbs_results.estimation
+    mbs_results.imputation
+    mbs_results.outlier_detection
+    mbs_results.outputs
+    mbs_results.staging
+    mbs_results.utilities
+include_package_data = True
 install_requires =
     pyyaml
     pandas
@@ -24,6 +31,8 @@ install_requires =
 python_requires = >=3.6
 zip_safe = no
 
+[options.packages.find]
+where = mbs_results
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
# Pull Request Title

Adding user ability to setup config.json and main.py when running the package in CML

# Summary

Added MANIFEST.ini file to explicitly include mbs_results/config.json in the package installation

Updated setup.cfg to manually include all packages modules to address problems with setuptools package auto discovery

Added a module mbs_results.start that includes a single function move_files. This copies mbs_results/main.py and mbs_results/config.py from the local Python environment install location into the current working directory.

# Type of Change

<!--
Please select the type of change that applies to this pull request.
-->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):


# Checklists

<!--
These are do-confirm checklists; it confirms that you have done each item.

If actions are irrelevant, please add a comment stating why.

Incomplete pull/merge requests may be blocked until actions are resolved, or closed at
the reviewers' discretion.
-->

This pull request meets the following requirements:

## Creator Checklist

- [x] Installable with all dependencies recorded
- [x] Runs without error
- [x] Follows PEP8 and project-specific conventions
- [x] Appropriate use of comments, for example, no descriptive comments
- [x] Functions documented using Numpy style docstrings
- [x] Assumptions and decisions log considered and updated if appropriate
- [ ] Unit tests have been updated to cover essential functionality for a reasonable range of inputs and conditions
- [ ] Other forms of testing such as end-to-end and user-interface testing have been considered and updated as required

Exception handling for mbs_results.start and unit tests to validate exception handling have not been added at this stage.

Testing suite results unchanged from previous commit.

## Reviewer Checklist

- [ ] Test suite passes (locally as a minimum)
- [ ] Peer reviewed with review recorded

# Additional Information

# Related Issues
