### PR TITLE
correct structure to call all RoM unit tests

### DIFF
--- a/tests/imputation/test_ratio_of_means.py
+++ b/tests/imputation/test_ratio_of_means.py
@@ -57,9 +57,7 @@ scenarios = [
 ]
 
 
-pytestmark = pytest.mark.parametrize("base_file_name", scenarios)
-
-
+@pytest.mark.parametrize("base_file_name", scenarios)
 class TestRatioOfMeans:
     def test_ratio_of_means(self, base_file_name):
 
@@ -166,16 +164,12 @@ class TestRatioOfMeans:
         assert_frame_equal(actual_output, expected_output, check_dtype=False)
 
 
-pytestmark = pytest.mark.parametrize(
-    "base_file_name", scenarios[len(scenarios) - 10 : len(scenarios)]
-)
-
-
+@pytest.mark.parametrize("mc_base_file_name", scenarios[-10:])
 class TestRatioOfMeansManConstruction:
-    def test_manual_construction_input(self, base_file_name):
-        df = pd.read_csv(scenario_path_prefix + base_file_name + "_input.csv")
+    def test_manual_construction_input(self, mc_base_file_name):
+        df = pd.read_csv(scenario_path_prefix + mc_base_file_name + "_input.csv")
         expected_output = pd.read_csv(
-            scenario_path_prefix + base_file_name + "_output.csv"
+            scenario_path_prefix + mc_base_file_name + "_output.csv"
         )
 
         manual_constructions = df.copy()[


### PR DESCRIPTION
# Pull Request Title

Correct structure for Ratio of means unit test

# Summary

Issue with not all unit tests being called for Ratio of means unit test cases.
No other issues with the unit tests!

# Type of Change

<!--
Please select the type of change that applies to this pull request.
-->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):


# Checklists

<!--
These are do-confirm checklists; it confirms that you have done each item.

If actions are irrelevant, please add a comment stating why.

Incomplete pull/merge requests may be blocked until actions are resolved, or closed at
the reviewers' discretion.
-->

This pull request meets the following requirements:

## Creator Checklist

- [x] Installable with all dependencies recorded
- [x] Runs without error
- [x] Follows PEP8 and project-specific conventions
- [x] Appropriate use of comments, for example, no descriptive comments
- [x] Functions documented using Numpy style docstrings
- [x] Assumptions and decisions log considered and updated if appropriate
- [x] Unit tests have been updated to cover essential functionality for a reasonable range of inputs and conditions
- [x] Other forms of testing such as end-to-end and user-interface testing have been considered and updated as required

If you feel some of these conditions do not apply for this pull request, please
add a comment to explain why.

## Reviewer Checklist

- [ ] Test suite passes (locally as a minimum)
- [ ] Peer reviewed with review recorded

# Additional Information

Please provide any additional information or context that would help the reviewer understand the changes in this pull request.

# Related Issues

Link any related issues or pull requests here.
