### PR TITLE
756 estimation validation review

### DIFF
--- a/mbs_results/utilities/validation_checks.py
+++ b/mbs_results/utilities/validation_checks.py
@@ -247,12 +247,41 @@ def validate_imputation(df: pd.DataFrame, config: dict):
 
 
 def validate_estimation(df: pd.DataFrame, config: dict):
-    warnings.warn("A placeholder function for validating dataframe post estimation")
-    output_path = config["output_path"]
-    file_version_mbs = metadata.metadata("monthly-business-survey-results")["version"]
-    snapshot_name = config["mbs_file_name"].split(".")[0]
-    estimate_filename = f"estimation_output_v{file_version_mbs}_{snapshot_name}.csv"
-    df.to_csv(output_path + estimate_filename, index=False)
+    """
+    Validates the estimation output.
+
+    Parameters
+    ----------
+    df: pd.DataFrame
+        the main dataframe after running the estimation part of the pipeline
+    config: Dict
+        The config dictionary.
+
+
+    Raises
+    ------
+    ValueError
+        ValueError if there are any null values in either the census or sampled columns.
+    """
+
+    # Placeholder code - commenting out for now
+
+    # output_path = config["output_path"]
+    # file_version_mbs = metadata.metadata("monthly-business-survey-results")["version"]
+    # snapshot_name = config["mbs_file_name"].split(".")[0]
+    # estimate_filename = f"estimation_output_v{file_version_mbs}_{snapshot_name}.csv"
+
+    census_nas = df[config["census"]].isna().sum()
+    if census_nas > 0:
+        raise ValueError(
+            f'There are {census_nas} NA(s) in the {config["census"]} column.'
+        )
+
+    sampled_nas = df[config["sampled"]].isna().sum()
+    if sampled_nas > 0:
+        raise ValueError(
+            f'There are {sampled_nas} NA(s) in the {config["sampled"]} column.'
+        )
 
 
 def validate_outlier_detection(df: pd.DataFrame, config: dict):

--- a/mbs_results/utilities/validation_checks.py
+++ b/mbs_results/utilities/validation_checks.py
@@ -264,12 +264,10 @@ def validate_estimation(df: pd.DataFrame, config: dict):
         ValueError if there are any null values in either the census or sampled columns.
     """
 
-    # Placeholder code - commenting out for now
-
-    # output_path = config["output_path"]
-    # file_version_mbs = metadata.metadata("monthly-business-survey-results")["version"]
-    # snapshot_name = config["mbs_file_name"].split(".")[0]
-    # estimate_filename = f"estimation_output_v{file_version_mbs}_{snapshot_name}.csv"
+    output_path = config["output_path"]
+    file_version_mbs = metadata.metadata("monthly-business-survey-results")["version"]
+    snapshot_name = config["mbs_file_name"].split(".")[0]
+    estimate_filename = f"estimation_output_v{file_version_mbs}_{snapshot_name}.csv"
 
     census_nas = df[config["census"]].isna().sum()
     if census_nas > 0:
@@ -282,6 +280,8 @@ def validate_estimation(df: pd.DataFrame, config: dict):
         raise ValueError(
             f'There are {sampled_nas} NA(s) in the {config["sampled"]} column.'
         )
+
+    df.to_csv(output_path + estimate_filename, index=False)
 
 
 def validate_outlier_detection(df: pd.DataFrame, config: dict):

--- a/tests/utilities/test_validation_checks.py
+++ b/tests/utilities/test_validation_checks.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -6,6 +7,7 @@ from mbs_results.utilities.validation_checks import (
     period_and_reference_not_given,
     validate_config_datatype_input,
     validate_config_repeated_datatypes,
+    validate_estimation,
     validate_indices,
 )
 
@@ -97,3 +99,33 @@ def test_validate_config_repeated_datatypes():
     }
     with pytest.raises(ValueError):
         validate_config_repeated_datatypes(**test_config)
+
+
+class TestValidateEstimation:
+
+    test_config = {
+        "census": "is_census",
+        "sampled": "is_sampled",
+    }
+
+    def test_validate_estimation_null_census(self):
+        test_data_dict = {
+            "is_sampled": [True, False, False, True, False],
+            "is_census": [False, True, True, np.nan, False],
+        }
+
+        test_data = pd.DataFrame(data=test_data_dict)
+
+        with pytest.raises(ValueError):
+            validate_estimation(df=test_data, config=self.test_config)
+
+    def test_validate_estimation_null_sampled(self):
+        test_data_dict = {
+            "is_sampled": [True, False, False, np.nan, False],
+            "is_census": [False, True, True, False, False],
+        }
+
+        test_data = pd.DataFrame(data=test_data_dict)
+
+        with pytest.raises(ValueError):
+            validate_estimation(df=test_data, config=self.test_config)

--- a/tests/utilities/test_validation_checks.py
+++ b/tests/utilities/test_validation_checks.py
@@ -106,6 +106,8 @@ class TestValidateEstimation:
     test_config = {
         "census": "is_census",
         "sampled": "is_sampled",
+        "mbs_file_name": "test_snaphot.json",
+        "output_path": "tests/data/utilities/validation_checks/outputs/",
     }
 
     def test_validate_estimation_null_census(self):


### PR DESCRIPTION
# Pull Request Title

756 estimation validation review

# Summary

This PR introduces the functionality outlined on [ASAP-756](https://jira.ons.gov.uk/secure/RapidBoard.jspa?rapidView=4001&projectKey=ASAP&view=detail&selectedIssue=ASAP-756#). It introduces a check within validate_estimation which produces an error message if either is_census or is_sampled contains a Null value.

# Type of Change

<!--
Please select the type of change that applies to this pull request.
-->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):


# Checklists

<!--
These are do-confirm checklists; it confirms that you have done each item.

If actions are irrelevant, please add a comment stating why.

Incomplete pull/merge requests may be blocked until actions are resolved, or closed at
the reviewers' discretion.
-->

This pull request meets the following requirements:

## Creator Checklist

- [x] Installable with all dependencies recorded
- [x] Runs without error
- [x] Follows PEP8 and project-specific conventions
- [x] Appropriate use of comments, for example, no descriptive comments
- [x] Functions documented using Numpy style docstrings
- [x] Assumptions and decisions log considered and updated if appropriate
- [x] Unit tests have been updated to cover essential functionality for a reasonable range of inputs and conditions
- [x] Other forms of testing such as end-to-end and user-interface testing have been considered and updated as required

If you feel some of these conditions do not apply for this pull request, please
add a comment to explain why.

## Reviewer Checklist

- [ ] Test suite passes (locally as a minimum)
- [ ] Peer reviewed with review recorded

# Additional Information

Please provide any additional information or context that would help the reviewer understand the changes in this pull request.

# Related Issues

Link any related issues or pull requests here.
