### PR TITLE
883 Derive additional periods

### DIFF
--- a/mbs_results/configs/README.md
+++ b/mbs_results/configs/README.md
@@ -17,9 +17,7 @@
 | back_data_finalsel_path | The filepath for the file containing final selection backdata. | string | Any filepath. |
 | sic_domain_mapping_path | The filepath for the data containing the mapping from SIC codes to domains. | string | Any filepath. |
 | threshold_filepath | The filepath for the data containing thresholds for selective editing. | string | Any filepath. |
-| period_selected | The most recent period to include in the outputs. | int | Any int in the form `yyyymm`. |
 | current_period | The most recent period to include in the outputs (same as above). | int | Any int in the form `yyyymm`. |
-| previous_period | The previous period to use as a reference | int | Any int in the form `yyyymm`. |
 | revision_window | The number of months to use as a revision window. | int | Any int in the form `mm` or `m` (does not need to be zero-padded). |
 
 

--- a/mbs_results/configs/config_user.json
+++ b/mbs_results/configs/config_user.json
@@ -1,6 +1,5 @@
 {
-    "bucket" : "",
-
+    "bucket": "",
     "calibration_group_map_path": "",
     "classification_values_path": "",
     "folder_path": "",
@@ -10,14 +9,11 @@
     "output_path": "",
     "population_path": "",
     "sample_path": "",
-    "back_data_qv_path":"",
-    "back_data_cp_path":"",
-    "back_data_finalsel_path":"",
+    "back_data_qv_path": "",
+    "back_data_cp_path": "",
+    "back_data_finalsel_path": "",
     "sic_domain_mapping_path": "",
-    "threshold_filepath":"",
-
-    "period_selected": 202303,
-    "current_period" : 202303,
-    "previous_period" : 202302,
+    "threshold_filepath": "",
+    "current_period": 202303,
     "revision_window": 13
 }

--- a/mbs_results/staging/stage_dataframe.py
+++ b/mbs_results/staging/stage_dataframe.py
@@ -253,7 +253,6 @@ def start_of_period_staging(
         - "finalsel_keep_cols": List of columns to keep in the final selection.
         - "sample_path": Path to the sample files.
         - "sample_column_names": Column names for the sample files.
-        - "period_selected": The period selected for final selection.
         - "idbr_to_spp": Mapping from IDBR to SPP.
         - "form_id_spp": Column name for form ID SPP.
         - "form_id_idbr": Column name for form ID IDBR.
@@ -267,6 +266,15 @@ def start_of_period_staging(
         The staged imputation output DataFrame with missing questions created and
         merged with final selection.
     """
+
+    # Derive period_selected as next month of current period
+    current_period = pd.to_datetime(config["current_period"], format="%Y%m")
+
+    period_selected = current_period + pd.DateOffset(months=1)
+
+    # Saving in the dictionary so it can easilly be accessed
+    config["period_selected"] = int(period_selected.strftime("%Y%m"))
+
     if config["current_period"] in imputation_output["period"].unique():
 
         imputation_output = imputation_output.loc[

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -19,9 +19,7 @@ test_config = {
     "back_data_qv_path": input_path + "test_qv_009_202112.csv",
     "back_data_cp_path": input_path + "test_cp_009_202112.csv",
     "back_data_finalsel_path": input_path + "test_finalsel009_202112",
-    "period_selected": 202206,
     "current_period": 202206,
-    "previous_period": 202205,
     "revision_window": 6,
 }
 


### PR DESCRIPTION
*Remove period_selected arg from config,ReadMe
*Add code to generate period_selected as next month current_period

# 883 Derive additional period
<!--
-->

# Summary

Minor change to derive selective editing period from current period to simplify the user config, `previous_period` arg wasn't be used anywhere thus removed it from config.

# Type of Change

<!--
Please select the type of change that applies to this pull request.
-->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):


# Checklists

<!--
These are do-confirm checklists; it confirms that you have done each item.

If actions are irrelevant, please add a comment stating why.

Incomplete pull/merge requests may be blocked until actions are resolved, or closed at
the reviewers' discretion.
-->

This pull request meets the following requirements:

## Creator Checklist

- [x] Installable with all dependencies recorded
- [x] Runs without error
- [x] Follows PEP8 and project-specific conventions
- [x] Appropriate use of comments, for example, no descriptive comments
- [x] Functions documented using Numpy style docstrings
- [x] Assumptions and decisions log considered and updated if appropriate
- [x] Unit tests have been updated to cover essential functionality for a reasonable range of inputs and conditions
- [x] Other forms of testing such as end-to-end and user-interface testing have been considered and updated as required

If you feel some of these conditions do not apply for this pull request, please
add a comment to explain why.

## Reviewer Checklist

- [ ] Test suite passes (locally as a minimum)
- [ ] Peer reviewed with review recorded

# Additional Information

Please provide any additional information or context that would help the reviewer understand the changes in this pull request.

# Related Issues

Link any related issues or pull requests here.
