### PR TITLE
Prioritise manual outliers weights in order

### DIFF
--- a/mbs_results/outlier_detection/detect_outlier.py
+++ b/mbs_results/outlier_detection/detect_outlier.py
@@ -2,7 +2,7 @@ import pandas as pd
 
 from mbs_results.outlier_detection.winsorisation import winsorise
 from mbs_results.utilities.constrains import (
-    replace_outlier_weights,
+    replace_with_manual_outlier_weights,
     update_derived_weight_and_winsorised_value,
 )
 from mbs_results.utilities.inputs import read_csv_wrapper
@@ -70,7 +70,7 @@ def detect_outlier(df, config):
     post_win.reset_index(drop=True, inplace=True)
 
     # Replace outlier weights
-    post_win = replace_outlier_weights(
+    post_win = replace_with_manual_outlier_weights(
         post_win,
         config["reference"],
         config["period"],

--- a/mbs_results/outlier_detection/detect_outlier.py
+++ b/mbs_results/outlier_detection/detect_outlier.py
@@ -69,16 +69,6 @@ def detect_outlier(df, config):
     # Remove groupby leftovers
     post_win.reset_index(drop=True, inplace=True)
 
-    post_win = update_derived_weight_and_winsorised_value(
-        post_win,
-        config["reference"],
-        config["period"],
-        config["question_no"],
-        config["form_id_spp"],
-        "outlier_weight",
-        config["target"],
-    )
-
     # Replace outlier weights
     post_win = replace_outlier_weights(
         post_win,
@@ -87,6 +77,15 @@ def detect_outlier(df, config):
         config["question_no"],
         "outlier_weight",
         config,
+    )
+    post_win = update_derived_weight_and_winsorised_value(
+        post_win,
+        config["reference"],
+        config["period"],
+        config["question_no"],
+        config["form_id_spp"],
+        "outlier_weight",
+        config["target"],
     )
 
     return post_win

--- a/mbs_results/utilities/constrains.py
+++ b/mbs_results/utilities/constrains.py
@@ -601,7 +601,7 @@ def update_derived_weight_and_winsorised_value(
     return df
 
 
-def replace_outlier_weights(
+def replace_with_manual_outlier_weights(
     df: pd.DataFrame,
     reference: str,
     period: str,

--- a/tests/utilities/test_constrains.py
+++ b/tests/utilities/test_constrains.py
@@ -8,8 +8,8 @@ from pandas.testing import assert_frame_equal
 from mbs_results.utilities.constrains import (
     calculate_derived_outlier_weights,
     constrain,
-    replace_outlier_weights,
     replace_values_index_based,
+    replace_with_manual_outlier_weights,
     sum_sub_df,
     update_derived_weight_and_winsorised_value,
 )
@@ -269,7 +269,7 @@ def test_replace_outlier_weights(filepath):
         "bucket": "",
     }
 
-    df_actual = replace_outlier_weights(
+    df_actual = replace_with_manual_outlier_weights(
         df_in,
         "reference",
         "period",
@@ -289,7 +289,7 @@ def test_no_manual_outliers(filepath):
 
     test_config = {"manual_outlier_path": "", "platform": "network", "bucket": ""}
 
-    df_actual = replace_outlier_weights(
+    df_actual = replace_with_manual_outlier_weights(
         df_in,
         "reference",
         "period",
@@ -314,7 +314,7 @@ def test_manual_outliers_unmatched_warning(filepath, caplog):
     }
 
     with caplog.at_level(logging.WARN):
-        replace_outlier_weights(
+        replace_with_manual_outlier_weights(
             df_in, "reference", "period", "question_no", "outlier_weight", test_config
         )
 


### PR DESCRIPTION
# Manual outlier not constrained

<!--
Please provide a descriptive title for the pull request.
-->

# Summary

Swapping the order of the functions, as users requested. When updating the derived weights we should use the manual outlier weights components if they are provided from users.

# Type of Change

<!--
Please select the type of change that applies to this pull request.
-->

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):


# Checklists

<!--
These are do-confirm checklists; it confirms that you have done each item.

If actions are irrelevant, please add a comment stating why.

Incomplete pull/merge requests may be blocked until actions are resolved, or closed at
the reviewers' discretion.
-->

This pull request meets the following requirements:

## Creator Checklist

- [x] Installable with all dependencies recorded
- [x] Runs without error
- [x] Follows PEP8 and project-specific conventions
- [x] Appropriate use of comments, for example, no descriptive comments
- [x] Functions documented using Numpy style docstrings
- [x] Assumptions and decisions log considered and updated if appropriate
- [x] Unit tests have been updated to cover essential functionality for a reasonable range of inputs and conditions
- [x] Other forms of testing such as end-to-end and user-interface testing have been considered and updated as required

If you feel some of these conditions do not apply for this pull request, please
add a comment to explain why.

## Reviewer Checklist

- [x] Test suite passes (locally as a minimum)
- [x] Peer reviewed with review recorded

# Additional Information

Please provide any additional information or context that would help the reviewer understand the changes in this pull request.

# Related Issues

Link any related issues or pull requests here.
